### PR TITLE
Revise documentation to update version flag

### DIFF
--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -45,7 +45,7 @@ Running mriqc
   ::
 
       
-      docker run -it poldracklab/mriqc:latest -v
+      docker run -it poldracklab/mriqc:latest --version
 
 
 2. Run the :code:`participant` level in subjects 001 002 003:


### PR DESCRIPTION
The documentation referenced `-v` to show version, but this gave an error currently; this updates this one line of the documentation to use the `--version` option (which then gives the version as expected).